### PR TITLE
[FIX] Views ignore 'next' url parameter

### DIFF
--- a/cookie_consent/views.py
+++ b/cookie_consent/views.py
@@ -29,11 +29,17 @@ class CookieGroupListView(ListView):
 class CookieGroupBaseProcessView(View):
 
     def get_success_url(self):
-        if hasattr(self.request, 'next'):
-            url = self.request.get("next")
-        else:
-            url = reverse('cookie_consent_cookie_group_list')
-        return url
+        """
+        If user adds a 'next' as URL parameter or hidden input, 
+        redirect to the value of 'next'. Otherwise, redirect to 
+        cookie consent group list
+        """
+        return (
+            self.request.POST.get('next') or self.request.GET.get(
+                'next', reverse('cookie_consent_cookie_group_list')
+            )
+	    )
+
 
     def process(self, request, response, varname):
         raise NotImplementedError()

--- a/tests/core/tests/test_views.py
+++ b/tests/core/tests/test_views.py
@@ -18,6 +18,21 @@ from cookie_consent.models import (
 )
 
 
+class CookieGroupBaseProcessViewTests(TestCase):
+
+    def test_get_success_url(self):
+        """
+        If user adds a 'next' as URL parameter it should,
+        redirect to the value of 'next'
+        """
+        expected_url = reverse('test_page')
+        url = "{}?next={}".format(
+            reverse('cookie_consent_accept_all'), expected_url
+        )
+        response = self.client.post(url, follow=True)
+        self.assertRedirects(response, expected_url)
+
+
 class IntegrationTest(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Request object doesn't have a get method. Only its GET or POST QueryDict does.
(unit tests pending)