### PR TITLE
Set max version for django-appconf

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,2 @@
 Django>=1.4
-django-appconf
+django-appconf<=1.0.3


### PR DESCRIPTION
As per issue # 17

django-appconf no longer supports python 2 from version 1.0.4 and up. 
Setting a maximum version in the requirements helps maintain python 2 compatibility.