### PR TITLE
Remove jquery

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,2 @@
 -r base.txt
 sphinx
-django-bootstrap4==1.1.1; python_version > '2.7'
-django-bootstrap4==0.0.4; python_version < '3.0'

--- a/tests/core/templates/test_page.html
+++ b/tests/core/templates/test_page.html
@@ -80,8 +80,21 @@
             cookie_groups.push("{{ cookie_group.varname }}");
           {% endfor %}
 
-          $(document).ready(function() {
-            $.showCookieBar({
+          function ready(fn) {
+	          if (document.readyState != 'loading') {
+	            fn();
+	          } else if (document.addEventListener) {
+	            document.addEventListener('DOMContentLoaded', fn);
+	          } else {
+	            document.attachEvent('onreadystatechange', function() {
+		          if (document.readyState != 'loading')
+		            fn();
+	            });
+	          }
+          }
+
+          ready(function() {
+	          showCookieBar({
               content: "{% filter escapejs %}{% with cookie_groups=cookie_groups|join:", " %}<div class="cookie-bar">This site uses {{ cookie_groups }} cookies for better performance and user experience. Do you agree to use cookies? <a href="{{ url_accept }}" class="cc-cookie-accept">Accept</a> <a href="{{ url_decline }}" class="cc-cookie-decline">Decline</a> <a href="{{ url_cookies }}">Cookies info</a></div>{% endwith %}{% endfilter %}",
               cookie_groups: cookie_groups,
               cookie_decline: "{% get_decline_cookie_groups_cookie_string request cookie_groups %}",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -6,7 +6,6 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.sites',
-    'bootstrap4',
     'django.contrib.messages',
 
     'cookie_consent',


### PR DESCRIPTION
I removed jQuey in favor of vanilla JS from the test app. 

Some things to note:

- The package bootstrap4 was throwing me Django 3-related errors. First I thought about upgrading it, but since I was unable to find it being used in any template, I simply removed it. Hope it's ok.
- The cookiebar.js is not a self invoked anonymous function anymore. Since I was not expanding jQuery anymore, I had to clutter the global namespace a little tiny bit.