### PR TITLE
Admin username is 'administrator', not 'admin'

### DIFF
--- a/docs/example_app.rst
+++ b/docs/example_app.rst
@@ -6,4 +6,4 @@ Example app
 
     cd tests && ./manage.py runserver
 
-Username and password for admin are 'admin', 'password'.
+Username and password for admin are 'administrator', 'password'.


### PR DESCRIPTION
Default admin username for example app was incorrectly stated as 'admin', when it is actually 'administrator' (as stated on the main GitHub page for the project).