### PR TITLE
Django 4.0 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: python
 matrix:
   include:
-    - name: "python 2 tests"
-      python: "2.7"
-      env: DJANGO_VERSION=1.9
     - name: "python 3 tests"
       python: "3.6"
-      env: DJANGO_VERSION=2.1
+      env: DJANGO_VERSION=2.2
     - name: "python 3 tests"
       python: "3.7"
       env: DJANGO_VERSION=3.0
+    - name: "python 3 tests"
+      python: "3.9"
+      env: DJANGO_VERSION=4.0
 install:
   - pip install -q Django==$DJANGO_VERSION
   - python setup.py -q install

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,7 +4,6 @@ The django-cookie-consent was created by Bojan Mihelac (bmihelac).
 The following is a list of much appreciated contributors:
 
 * Jonathan L Herr (JonHerr)
-* MrCordeiro (Fernando) 
 * Jasper Koops (Jasper-Koops)
-* MrCordeiro (Fernando MrCordeiro)
+* Fernando Cordeiro (MrCordeiro)
 * Mejans

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Django cookie consent
 django-cookie-consent is a reusable application for managing various
 cookies and visitors consent for their use in Django project.
 
-support ranges from django 1.9 to 3.0 and python 2.7 to 3.7
+Support ranges from django 2.2 to 4.0 and python 3.6 to 3.9
 
 Features:
 

--- a/cookie_consent/admin.py
+++ b/cookie_consent/admin.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.contrib import admin
 from .conf import settings
 from .models import (

--- a/cookie_consent/cache.py
+++ b/cookie_consent/cache.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from django.core.cache import caches
 from cookie_consent.conf import settings
-try:
-    from django.core.cache import get_cache
-    cache = get_cache(settings.COOKIE_CONSENT_CACHE_BACKEND)
-except ImportError:
-    from django.core.cache import caches
-    cache = caches[settings.COOKIE_CONSENT_CACHE_BACKEND]
+
+
+cache = caches[settings.COOKIE_CONSENT_CACHE_BACKEND]
 
 
 

--- a/cookie_consent/conf.py
+++ b/cookie_consent/conf.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.conf import settings  # NOQA
 
 from appconf import AppConf

--- a/cookie_consent/forms.py
+++ b/cookie_consent/forms.py
@@ -1,4 +1,0 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-from django import forms

--- a/cookie_consent/managers.py
+++ b/cookie_consent/managers.py
@@ -1,4 +1,0 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-#from django.db.models.query import QuerySet

--- a/cookie_consent/middleware.py
+++ b/cookie_consent/middleware.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.utils.encoding import smart_str
 
 from cookie_consent.cache import all_cookie_groups

--- a/cookie_consent/models.py
+++ b/cookie_consent/models.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import re
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.core.validators import RegexValidator
 
 from cookie_consent.cache import delete_cache

--- a/cookie_consent/templatetags/cookie_consent_tags.py
+++ b/cookie_consent/templatetags/cookie_consent_tags.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django import template
 try:
     from django.urls import reverse

--- a/cookie_consent/urls.py
+++ b/cookie_consent/urls.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-from django.conf.urls import url
+from django.urls import re_path
 from django.views.decorators.csrf import csrf_exempt
 
 from .views import (
@@ -11,19 +9,19 @@ from .views import (
 )
 
 urlpatterns = [
-    url(r'^accept/$',
+    re_path(r'^accept/$',
         csrf_exempt(CookieGroupAcceptView.as_view()),
         name='cookie_consent_accept_all'),
-    url(r'^accept/(?P<varname>.*)/$',
+    re_path(r'^accept/(?P<varname>.*)/$',
         csrf_exempt(CookieGroupAcceptView.as_view()),
         name='cookie_consent_accept'),
-    url(r'^decline/(?P<varname>.*)/$',
+    re_path(r'^decline/(?P<varname>.*)/$',
         csrf_exempt(CookieGroupDeclineView.as_view()),
         name='cookie_consent_decline'),
-    url(r'^decline/$',
+    re_path(r'^decline/$',
         csrf_exempt(CookieGroupDeclineView.as_view()),
         name='cookie_consent_decline_all'),
-    url(r'^$',
+    re_path(r'^$',
         CookieGroupListView.as_view(),
         name='cookie_consent_cookie_group_list'),
 ]

--- a/cookie_consent/util.py
+++ b/cookie_consent/util.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import datetime
 
 from django.utils.encoding import smart_str

--- a/cookie_consent/views.py
+++ b/cookie_consent/views.py
@@ -1,10 +1,6 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-try:
-    from django.urls import reverse
-except ImportError:
-    from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, HttpResponse
+from django.urls import reverse
 from django.views.generic import (
     ListView,
     View,
@@ -46,7 +42,7 @@ class CookieGroupBaseProcessView(View):
 
     def post(self, request, *args, **kwargs):
         varname = kwargs.get('varname', None)
-        if request.is_ajax():
+        if request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest':
             response = HttpResponse()
         else:
             response = HttpResponseRedirect(self.get_success_url())

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,10 +2,10 @@
 Change Log
 ===========
 
-0.2.7 (unreleased)
+0.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+* support ranges from django 2.2 to 4.0 and python 3.6 to 3.9
 
 
 0.2.6 (2020-06-17)

--- a/setup.py
+++ b/setup.py
@@ -6,24 +6,26 @@ version = '0.2.7.dev0'
 
 CLASSIFIERS = [
     'Framework :: Django',
-    'Framework :: Django :: 1.9',
-    'Framework :: Django :: 2.1',
     'Framework :: Django :: 2.2',
-    'Framework :: Django :: 3.0',    
+    'Framework :: Django :: 3.0',
+    'Framework :: Django :: 3.1',     
+    'Framework :: Django :: 3.2',     
+    'Framework :: Django :: 4.0',     
     'Intended Audience :: Developers',
     'License :: OSI Approved :: BSD License',
     'Operating System :: OS Independent',
     'Topic :: Software Development',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
 ]
 
 install_requires = [
-    'Django>=1.9',
+    'Django>=2.2',
     'django-appconf',
 ]
 

--- a/tests/core/tests/test_cache.py
+++ b/tests/core/tests/test_cache.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.test import (
     TestCase,
 )
-from django.test.utils import override_settings
 
 from cookie_consent.models import (
     Cookie,

--- a/tests/core/tests/test_models.py
+++ b/tests/core/tests/test_models.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.core.exceptions import ValidationError
 from django.test import (
     TestCase,

--- a/tests/core/tests/test_util.py
+++ b/tests/core/tests/test_util.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from datetime import datetime
 
 from django.test import (

--- a/tests/core/tests/test_views.py
+++ b/tests/core/tests/test_views.py
@@ -1,14 +1,9 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-try:
-    from django.urls import reverse
-except ImportError:
-    from django.core.urlresolvers import reverse
 from django.test import (
     TestCase,
 )
 from django.test.utils import override_settings
+from django.urls import reverse
 
 from cookie_consent.models import (
     Cookie,

--- a/tests/core/urls.py
+++ b/tests/core/urls.py
@@ -1,14 +1,10 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-from django.conf.urls import url
+from django.urls import path
 
 from .views import (
     TestPageView,
 )
 
 urlpatterns = [
-    url(r'^$',
-        TestPageView.as_view(),
-        name='test_page'),
+    path("", TestPageView.as_view(), name='test_page'),
 ]

--- a/tests/core/views.py
+++ b/tests/core/views.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-from django.views.generic import (
-    TemplateView,
-)
+from django.views.generic import TemplateView
 from cookie_consent.util import get_cookie_value_from_request
 
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -47,6 +47,7 @@ DATABASES = {
         'NAME': os.path.join(os.path.dirname(__file__), 'database.db'),
     }
 }
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 MIDDLEWARE_CLASSES = MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 
@@ -7,9 +7,9 @@ admin.autodiscover()
 
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^cookies/', include('cookie_consent.urls')),
-    url(r'', include('core.urls')),
+    path('admin/', admin.site.urls),
+    path('cookies/', include('cookie_consent.urls')),
+    path('', include('core.urls')),
 ]
 
 urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
- Replace `.is_ajax()` for HTTP_X_REQUESTED_WITH header validation (deprecated on Django 3.1)
- Replace `ugettext_lazy` for `gettext_lazy `(deprecated on Django 4.0)
- Replace `url` for `path` and `re_path` on `urls.py`
- Add python 3.9 + Django 4.0 on travis
- My name was showing up twice on Authors so I removed one.