### PR TITLE
Improved COOKIE_CONSENT_OPT_OUT setting from the docs with sentences

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -26,9 +26,9 @@ Settings
   Default: ``True``
 
 ``COOKIE_CONSENT_OPT_OUT``
-  Boolean value represents if cookies are opt-in or opt-out
-  opt-out cookies are set until declined
-  opt-in cookies are set only if accepted
+  Boolean value represents if cookies are opt-in or opt-out.
+  Opt-out cookies are set until declined.
+  Opt-in cookies are set only if accepted.
 
   Default: ``False``
 


### PR DESCRIPTION
I made this setting a little bit easier to understand. Without period separation, it was a confusing run on sentence. 