### PR TITLE
Define broader test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,23 @@
 language: python
+
+python:
+  - '3.6'
+  - '3.7'
+  - '3.8'
+  - '3.9'
+
+env:
+  - DJANGO_VERSION=2.2
+  - DJANGO_VERSION=3.2
+  - DJANGO_VERSION=4.0
+
 matrix:
-  include:
-    - name: "python 3 tests"
-      python: "3.6"
-      env: DJANGO_VERSION=2.2
-    - name: "python 3 tests"
-      python: "3.7"
-      env: DJANGO_VERSION=3.0
-    - name: "python 3 tests"
-      python: "3.9"
+  exclude:
+    - python: '3.6'
       env: DJANGO_VERSION=4.0
+    - python: '3.7'
+      env: DJANGO_VERSION=4.0
+
 install:
   - pip install -q Django==$DJANGO_VERSION
   - python setup.py -q install


### PR DESCRIPTION
Added Travis CI matrix expansion, ranging from Python 3.6 to 3.9,
combining with Django 2.2, 3.2 and 4.0.

Django 3.0 and 3.1 are end of life, while 2.2 and 3.2 are LTS releases.